### PR TITLE
Optimize graphics storage for large projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     },
     "dependencies": {
         "@types/dom-serial": "^1.0.4",
+        "base64-arraybuffer": "^1.0.2",
+        "pako": "^2.1.0",
         "typescript": "^5.2.2",
         "vue": "^3.3.4"
     }

--- a/src/core/layers/icon.layer.ts
+++ b/src/core/layers/icon.layer.ts
@@ -1,5 +1,5 @@
 import {TPlatformFeatures} from '../../platforms/platform';
-import {inverImageDataWithAlpha} from '../../utils';
+import {inverImageDataWithAlpha, packImage, unpackImage} from '../../utils';
 import {Point} from '../point';
 import {Rect} from '../rect';
 import {AbstractLayer, EditMode, TLayerModifier, TLayerModifiers, TLayerState, TModifierType} from './abstract.layer';
@@ -7,7 +7,7 @@ import {AbstractLayer, EditMode, TLayerModifier, TLayerModifiers, TLayerState, T
 type TIconState = TLayerState & {
     p: number[]; // position [x, y]
     s: number[]; // size [w, h]
-    d: number[]; // data
+    d: string; // data
     in: string; // image name
     o: boolean; // is overlay
 };
@@ -144,10 +144,11 @@ export class IconLayer extends AbstractLayer {
     }
 
     saveState() {
+        if (!this.image) return;
         const state: TIconState = {
             p: this.position.xy,
             s: this.size.xy,
-            d: Array.from(this.image?.data || []), //TODO image data
+            d: packImage(this.image), //TODO image data
             in: this.imageName,
             n: this.name,
             i: this.index,
@@ -165,7 +166,7 @@ export class IconLayer extends AbstractLayer {
         this.name = state.n;
         this.index = state.i;
         this.group = state.g;
-        this.image = new ImageData(new Uint8ClampedArray(state.d), this.size.x, this.size.y);
+        this.image = unpackImage(state.d);
         this.imageName = state.in;
         this.overlay = state.o;
         this.uid = state.u;

--- a/src/core/layers/icon.layer.ts
+++ b/src/core/layers/icon.layer.ts
@@ -166,7 +166,7 @@ export class IconLayer extends AbstractLayer {
         this.name = state.n;
         this.index = state.i;
         this.group = state.g;
-        this.image = unpackImage(state.d);
+        this.image = unpackImage(state.d, this.size.x, this.size.y);
         this.imageName = state.in;
         this.overlay = state.o;
         this.uid = state.u;

--- a/src/core/layers/icon.layer.ts
+++ b/src/core/layers/icon.layer.ts
@@ -64,6 +64,18 @@ export class IconLayer extends AbstractLayer {
                     this.image = ctx.getImageData(0, 0, v.width, v.height);
                 }
                 this.size = new Point(v.width, v.height);
+                // uncomment to see compression ratio
+                // const png = buf.toDataURL();
+                // const zlib = packImage(this.image);
+                // console.log(
+                //     this.imageName,
+                //     'png:',
+                //     png.length,
+                //     'zlib:',
+                //     zlib.length,
+                //     '%',
+                //     (zlib.length / png.length) * 100
+                // );
                 this.updateBounds();
                 this.saveState();
                 this.draw();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,8 @@
+// import {PNG} from 'pngjs/browser';
+import {decode, encode} from 'base64-arraybuffer';
+// import {deflateRawSync, deflateSync, inflateRawSync, inflateSync} from 'zlib';
+import pako from 'pako';
+
 function bitswap(b) {
     b = ((b & 0xf0) >> 4) | ((b & 0x0f) << 4);
     b = ((b & 0xcc) >> 2) | ((b & 0x33) << 2);
@@ -216,4 +221,18 @@ export function debounce(func, delay = 500) {
         clearTimeout(timeoutId);
         timeoutId = setTimeout(() => func.apply(context, args), delay);
     };
+}
+
+export function packImage(imageData: ImageData): string {
+    const deflate = new pako.Deflate({level: 9});
+    deflate.push(imageData.data, true);
+    return `${imageData.width},${imageData.height},${encode(deflate.result)}`;
+}
+
+export function unpackImage(data: string): ImageData {
+    const [width, height, base64] = data.split(',');
+    const inflate = new pako.Inflate({level: 9});
+    const arr = new Uint8Array(decode(base64));
+    inflate.push(arr, true);
+    return new ImageData(new Uint8ClampedArray(inflate.result), parseInt(width), parseInt(height));
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,4 @@
-// import {PNG} from 'pngjs/browser';
 import {decode, encode} from 'base64-arraybuffer';
-// import {deflateRawSync, deflateSync, inflateRawSync, inflateSync} from 'zlib';
 import pako from 'pako';
 
 function bitswap(b) {
@@ -226,13 +224,12 @@ export function debounce(func, delay = 500) {
 export function packImage(imageData: ImageData): string {
     const deflate = new pako.Deflate({level: 9});
     deflate.push(imageData.data, true);
-    return `${imageData.width},${imageData.height},${encode(deflate.result)}`;
+    return encode(deflate.result);
 }
 
-export function unpackImage(data: string): ImageData {
-    const [width, height, base64] = data.split(',');
+export function unpackImage(base64: string, width: number, height: number): ImageData {
     const inflate = new pako.Inflate({level: 9});
     const arr = new Uint8Array(decode(base64));
     inflate.push(arr, true);
-    return new ImageData(new Uint8ClampedArray(inflate.result), parseInt(width), parseInt(height));
+    return new ImageData(new Uint8ClampedArray(inflate.result), width, height);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,6 +475,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-arraybuffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1047,6 +1052,11 @@ p-limit@^4.0.0:
   integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
   dependencies:
     yocto-queue "^1.0.0"
+
+pako@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 parse5@^7.1.2:
   version "7.1.2"


### PR DESCRIPTION
<img width="907" alt="image" src="https://github.com/sbrin/lopaka/assets/804731/79b8f73e-ed55-4b66-9056-c85a0063a235">
Comparing packed image length (png vs zlib)

Also zlib can be used synchronously, unlike loading an image from a URL

JSON data of this example:

`[{"p":[78,17],"s":[35,43],"d":"eNrt18EKwCAMA9D8/0+70w6CjHUkNcPkJDvIY9qqwJyxKTBxrDyr7x3jWP5vcdq7scQSS58FD+m04EU6LCikOuc9Zt01vngUDoZHsabKOo3F36La525vDIWZ0et2v7mYFtbZ6HTmV/uvonYZDmYfYaxR7qra/5vkbXN6HSVn1KKL4wLy4W2e","in":"SDQuestion_35x43","n":"SDQuestion_35x43","i":6,"t":"icon","o":false,"u":"0qh46zmh2ciolplv3yhv"},{"p":[49,2],"s":[25,27],"d":"eNrllckNACAMw7L/0uUJD0SFaPygHqBW1EuaRCHaEAbc9VdPNIXITvSPchCzTjmIu1DtcTtOtas8WYZXhxIqsugCZxZ3P4jZcuw7cU+689vPcf6DAXfDo80=","in":"Dehumidify_hvr_25x27","n":"Dehumidify_hvr_25x27","i":5,"t":"icon","o":false,"u":"uq3ha6pld3hlplv3ugl"},{"p":[27,1],"s":[18,21],"d":"eNpjYICA/1DAQCTApp5UM7Dp+48EyDUHGyCkhhgzBgOghhup5VdqmkOuH6kRp8SmDWqqwaaOnPRMyJyhmA4JhSGpYYFuFzFhT078kFs2kVPmkaofAHq/BDU=","in":"EviSmile1_18x21","n":"EviSmile1_18x21","i":4,"t":"icon","o":false,"u":"nltlxy796vlplv3pn2"},{"p":[10,0],"s":[13,13],"d":"eNpjYECA/3gAAxbwnwiASz0h8wjxyRXHJz/c9JAiTk78kJsOSE1vAKH94iw=","in":"Ok_btn_pressed_13x13","n":"Ok_btn_pressed_13x13","i":3,"t":"icon","o":false,"u":"52ere6fjdllplv3kra"},{"p":[5,0],"s":[3,5],"d":"eNr7////fwYo+A8FyGxkABOHqQcAhe4j3Q==","in":"ButtonRightSmall_3x5","n":"ButtonRightSmall_3x5","i":2,"t":"icon","o":false,"u":"5tob200a7qvlplv3dfq"},{"p":[0,0],"s":[3,5],"d":"eNpjYICA/0AAo9EBsjgDknoABm4j3Q==","in":"ButtonLeftSmall_3x5","n":"ButtonLeftSmall_3x5","i":1,"t":"icon","o":false,"u":"r9dxd230zjlplv3bk4"}]`