### PR TITLE
Paint tool improvements rebased

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -76,9 +76,9 @@ function addImageToCanvas(data) {
     newLayer.name = data.name;
     newLayer.size = new Point(data.width, data.height);
     newLayer.selected = true;
+    newLayer.modifiers.icon.setValue(data.icon);
     newLayer.stopEdit();
     session.addLayer(newLayer);
-    newLayer.modifiers.icon.setValue(data.icon);
     virtualScreen.redraw();
 }
 

--- a/src/components/fui/FuiInspector.vue
+++ b/src/components/fui/FuiInspector.vue
@@ -103,6 +103,7 @@ function onChange(event: Event, param: TLayerModifier) {
                         type="number"
                         :value="param.getValue()"
                         @change="onChange($event, param)"
+                        :readonly="!param.setValue"
                     />
                 </div>
                 <div v-else-if="param.type == TModifierType.string">
@@ -111,6 +112,7 @@ function onChange(event: Event, param: TLayerModifier) {
                         type="text"
                         :value="param.getValue()"
                         @keyup="onChange($event, param)"
+                        :readonly="!param.setValue"
                     />
                 </div>
                 <div v-else-if="param.type == TModifierType.boolean">
@@ -119,6 +121,7 @@ function onChange(event: Event, param: TLayerModifier) {
                         type="checkbox"
                         :checked="param.getValue()"
                         @change="onChange($event, param)"
+                        :readonly="!param.setValue"
                     />
                 </div>
                 <div v-else-if="param.type == TModifierType.color">
@@ -127,11 +130,17 @@ function onChange(event: Event, param: TLayerModifier) {
                         type="color"
                         :value="param.getValue()"
                         @input="onChange($event, param)"
+                        :readonly="!param.setValue"
                         list="presetColors"
                     />
                 </div>
                 <div v-else-if="param.type == TModifierType.font">
-                    <select class="inspector__input" :value="param.getValue()" @change="onChange($event, param)">
+                    <select
+                        class="inspector__input"
+                        :value="param.getValue()"
+                        :readonly="!param.setValue"
+                        @change="onChange($event, param)"
+                    >
                         <option v-for="font in fonts" :value="font.name">{{ font.title }}</option>
                     </select>
                 </div>

--- a/src/core/layers/abstract-image.layer.ts
+++ b/src/core/layers/abstract-image.layer.ts
@@ -1,3 +1,4 @@
+import {TPlatformFeatures} from '../../platforms/platform';
 import {packImage, unpackImage} from '../../utils';
 import {Point} from '../point';
 import {Rect} from '../rect';
@@ -25,6 +26,10 @@ export abstract class AbstractImageLayer extends AbstractLayer {
     public data: ImageData;
     public overlay: boolean;
     public imageName: string;
+
+    constructor(protected features: TPlatformFeatures) {
+        super(features);
+    }
 
     draw() {
         const {dc, position, data, size} = this;

--- a/src/core/layers/abstract-image.layer.ts
+++ b/src/core/layers/abstract-image.layer.ts
@@ -10,6 +10,7 @@ export type TImageState = TLayerState & {
     d: string; // data
     nm: string; // name
     o: boolean; // overlay
+    c?: string; // color
 };
 
 export abstract class AbstractImageLayer extends AbstractLayer {
@@ -54,7 +55,8 @@ export abstract class AbstractImageLayer extends AbstractLayer {
             g: this.group,
             t: this.type,
             o: this.overlay,
-            u: this.uid
+            u: this.uid,
+            c: this.color
         };
         this.state = state;
     }
@@ -66,6 +68,13 @@ export abstract class AbstractImageLayer extends AbstractLayer {
         this.index = state.i;
         this.group = state.g;
         this.data = unpackImage(state.d, this.size.x, this.size.y);
+        this.color = state.c || this.features.defaultColor;
+        try {
+            this.data = unpackImage(state.d, this.size.x, this.size.y);
+        } catch (error) {
+            // TODO: fix types for backwards compatibility with uncompressed images
+            this.data = new ImageData(new Uint8ClampedArray(state.d as any), this.size.x, this.size.y);
+        }
         this.imageName = state.nm;
         this.overlay = state.o;
         this.uid = state.u;

--- a/src/core/layers/abstract-image.layer.ts
+++ b/src/core/layers/abstract-image.layer.ts
@@ -1,0 +1,74 @@
+import {packImage, unpackImage} from '../../utils';
+import {Point} from '../point';
+import {Rect} from '../rect';
+import {AbstractLayer, EditMode, TLayerEditPoint, TLayerState} from './abstract.layer';
+
+export type TImageState = TLayerState & {
+    p: number[]; // position
+    s: number[]; // size
+    d: string; // data
+    nm: string; // name
+    o: boolean; // overlay
+};
+
+export abstract class AbstractImageLayer extends AbstractLayer {
+    protected type: ELayerType;
+    protected state: TImageState;
+    protected editState: {
+        firstPoint: Point;
+        position: Point;
+        size: Point;
+    } = null;
+
+    public position: Point = new Point();
+    public size: Point = new Point();
+    public data: ImageData;
+    public overlay: boolean;
+    public imageName: string;
+
+    draw() {
+        const {dc, position, data, size} = this;
+        dc.clear();
+        dc.ctx.putImageData(data, position.x, position.y);
+        dc.ctx.save();
+        dc.ctx.fillStyle = 'rgba(0,0,0,0)';
+        dc.ctx.beginPath();
+        dc.ctx.rect(position.x, position.y, size.x, size.y);
+        dc.ctx.fill();
+        dc.ctx.restore();
+    }
+
+    saveState() {
+        const state: TImageState = {
+            p: this.position.xy,
+            s: this.size.xy,
+            d: packImage(this.data),
+            nm: this.imageName,
+            n: this.name,
+            i: this.index,
+            g: this.group,
+            t: this.type,
+            o: this.overlay,
+            u: this.uid
+        };
+        this.state = state;
+    }
+
+    loadState(state: TImageState) {
+        this.position = new Point(state.p);
+        this.size = new Point(state.s);
+        this.name = state.n;
+        this.index = state.i;
+        this.group = state.g;
+        this.data = unpackImage(state.d, this.size.x, this.size.y);
+        this.imageName = state.nm;
+        this.overlay = state.o;
+        this.uid = state.u;
+        this.updateBounds();
+        this.mode = EditMode.NONE;
+    }
+
+    updateBounds(): void {
+        this.bounds = new Rect(this.position, this.size);
+    }
+}

--- a/src/core/layers/abstract.layer.ts
+++ b/src/core/layers/abstract.layer.ts
@@ -40,7 +40,7 @@ export type TModifierName =
     | 'fontSize';
 
 export type TLayerModifier = {
-    setValue(value: any): void;
+    setValue?(value: any): void;
     getValue(): any;
     type: TModifierType;
 };

--- a/src/core/layers/circle.layer.ts
+++ b/src/core/layers/circle.layer.ts
@@ -213,6 +213,7 @@ export class CircleLayer extends AbstractLayer {
         this.uid = state.u;
         this.color = state.c;
         this.updateBounds();
+        this.mode = EditMode.NONE;
     }
 
     updateBounds() {

--- a/src/core/layers/icon.layer.ts
+++ b/src/core/layers/icon.layer.ts
@@ -1,31 +1,11 @@
 import {TPlatformFeatures} from '../../platforms/platform';
-import {inverImageDataWithAlpha, packImage, unpackImage} from '../../utils';
+import {inverImageDataWithAlpha} from '../../utils';
 import {Point} from '../point';
-import {Rect} from '../rect';
-import {AbstractLayer, EditMode, TLayerModifier, TLayerModifiers, TLayerState, TModifierType} from './abstract.layer';
+import {AbstractImageLayer} from './abstract-image.layer';
+import {EditMode, TLayerModifiers, TModifierType} from './abstract.layer';
 
-type TIconState = TLayerState & {
-    p: number[]; // position [x, y]
-    s: number[]; // size [w, h]
-    d: string; // data
-    in: string; // image name
-    o: boolean; // is overlay
-};
-
-export class IconLayer extends AbstractLayer {
+export class IconLayer extends AbstractImageLayer {
     protected type: ELayerType = 'icon';
-    protected state: TIconState;
-    protected editState: {
-        firstPoint: Point;
-        position: Point;
-        size: Point;
-    } = null;
-
-    public position: Point = new Point();
-    public size: Point = new Point();
-    public image: ImageData = null;
-    public imageName: string = '';
-    public overlay: boolean = false;
 
     modifiers: TLayerModifiers = {
         x: {
@@ -49,8 +29,16 @@ export class IconLayer extends AbstractLayer {
             },
             type: TModifierType.number
         },
+        w: {
+            getValue: () => this.size.x,
+            type: TModifierType.number
+        },
+        h: {
+            getValue: () => this.size.y,
+            type: TModifierType.number
+        },
         icon: {
-            getValue: () => this.image,
+            getValue: () => this.data,
             setValue: (v: HTMLImageElement) => {
                 this.imageName = v.dataset.name;
                 const buf = document.createElement('canvas');
@@ -59,23 +47,11 @@ export class IconLayer extends AbstractLayer {
                 buf.height = v.height;
                 ctx.drawImage(v, 0, 0);
                 if (this.features.hasInvertedColors) {
-                    this.image = inverImageDataWithAlpha(ctx.getImageData(0, 0, v.width, v.height));
+                    this.data = inverImageDataWithAlpha(ctx.getImageData(0, 0, v.width, v.height));
                 } else {
-                    this.image = ctx.getImageData(0, 0, v.width, v.height);
+                    this.data = ctx.getImageData(0, 0, v.width, v.height);
                 }
                 this.size = new Point(v.width, v.height);
-                // uncomment to see compression ratio
-                // const png = buf.toDataURL();
-                // const zlib = packImage(this.image);
-                // console.log(
-                //     this.imageName,
-                //     'png:',
-                //     png.length,
-                //     'zlib:',
-                //     zlib.length,
-                //     '%',
-                //     (zlib.length / png.length) * 100
-                // );
                 this.updateBounds();
                 this.saveState();
                 this.draw();
@@ -104,9 +80,6 @@ export class IconLayer extends AbstractLayer {
 
     constructor(protected features: TPlatformFeatures) {
         super(features);
-        if (!this.features.hasCustomFontSize) {
-            delete this.modifiers.fontSize;
-        }
         if (!this.features.hasRGBSupport) {
             delete this.modifiers.color;
         }
@@ -137,60 +110,5 @@ export class IconLayer extends AbstractLayer {
         this.editState = null;
         this.saveState();
         this.history.push(this.state);
-    }
-
-    draw() {
-        const {dc, position, image, size} = this;
-        dc.clear();
-        if (image) {
-            dc.ctx.putImageData(image, position.x, position.y);
-        } else {
-            dc.rect(position, size, false);
-        }
-        dc.ctx.save();
-        dc.ctx.fillStyle = 'rgba(0,0,0,0)';
-        dc.ctx.beginPath();
-        dc.ctx.rect(position.x, position.y, size.x, size.y);
-        dc.ctx.fill();
-        dc.ctx.restore();
-    }
-
-    saveState() {
-        if (!this.image) return;
-        const state: TIconState = {
-            p: this.position.xy,
-            s: this.size.xy,
-            d: packImage(this.image), //TODO image data
-            in: this.imageName,
-            n: this.name,
-            i: this.index,
-            g: this.group,
-            t: this.type,
-            o: this.overlay,
-            u: this.uid
-        };
-        this.state = state;
-    }
-
-    loadState(state: TIconState) {
-        this.position = new Point(state.p);
-        this.size = new Point(state.s);
-        this.name = state.n;
-        this.index = state.i;
-        this.group = state.g;
-        try {
-            this.image = unpackImage(state.d, this.size.x, this.size.y);
-        } catch (error) {
-            // TODO: fix types for backwards compatibility with uncompressed images
-            this.image = new ImageData(new Uint8ClampedArray(state.d), this.size.x, this.size.y);
-        }
-        this.imageName = state.in;
-        this.overlay = state.o;
-        this.uid = state.u;
-        this.updateBounds();
-    }
-
-    updateBounds(): void {
-        this.bounds = new Rect(this.position, this.size);
     }
 }

--- a/src/core/layers/line.layer.ts
+++ b/src/core/layers/line.layer.ts
@@ -171,6 +171,7 @@ export class LineLayer extends AbstractLayer {
         this.uid = state.u;
         this.color = state.c;
         this.updateBounds();
+        this.mode = EditMode.NONE;
     }
 
     updateBounds() {

--- a/src/core/layers/paint.layer.ts
+++ b/src/core/layers/paint.layer.ts
@@ -29,6 +29,14 @@ export class PaintLayer extends AbstractImageLayer {
             },
             type: TModifierType.number
         },
+        w: {
+            getValue: () => this.size.x,
+            type: TModifierType.number
+        },
+        h: {
+            getValue: () => this.size.y,
+            type: TModifierType.number
+        },
         color: {
             getValue: () => this.color,
             setValue: (v: string) => {
@@ -45,14 +53,6 @@ export class PaintLayer extends AbstractImageLayer {
             },
             type: TModifierType.color
         },
-        w: {
-            getValue: () => this.size.x,
-            type: TModifierType.number
-        },
-        h: {
-            getValue: () => this.size.y,
-            type: TModifierType.number
-        }
     };
 
     constructor(protected features: TPlatformFeatures) {

--- a/src/core/layers/paint.layer.ts
+++ b/src/core/layers/paint.layer.ts
@@ -28,6 +28,13 @@ export class PaintLayer extends AbstractImageLayer {
             },
             type: TModifierType.number
         },
+        color: {
+            getValue: () => this.color,
+            setValue: (v: string) => {
+                this.color = v;
+            },
+            type: TModifierType.color
+        },
         w: {
             getValue: () => this.size.x,
             type: TModifierType.number

--- a/src/core/layers/paint.layer.ts
+++ b/src/core/layers/paint.layer.ts
@@ -95,13 +95,7 @@ export class PaintLayer extends AbstractImageLayer {
                     if (position.distanceTo(point) < 1) {
                         ctx.rect(point.x, point.y, 1, 1);
                     } else {
-                        const diff = point.clone().subtract(position);
-                        const steps = Math.max(Math.abs(diff.x), Math.abs(diff.y));
-                        const step = diff.clone().divide(steps);
-                        for (let i = 0; i < steps; i++) {
-                            const p = position.clone().add(step.clone().multiply(i)).round();
-                            ctx.rect(p.x, p.y, 1, 1);
-                        }
+                        this.dc.pixelateLine(position, point, 1);
                     }
                     ctx.fillStyle = this.color;
                     ctx.fill();

--- a/src/core/layers/rectangle.layer.ts
+++ b/src/core/layers/rectangle.layer.ts
@@ -213,6 +213,7 @@ export abstract class RectangleLayer extends AbstractLayer {
         this.uid = state.u;
         this.color = state.c;
         this.updateBounds();
+        this.mode = EditMode.NONE;
     }
 
     updateBounds(): void {

--- a/src/core/layers/text.layer.ts
+++ b/src/core/layers/text.layer.ts
@@ -182,6 +182,7 @@ export class TextLayer extends AbstractLayer {
         this.scaleFactor = state.z;
         this.color = state.c;
         this.updateBounds();
+        this.mode = EditMode.NONE;
     }
 
     updateBounds(): void {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -227,8 +227,8 @@ export function loadLayers(layers: any[]) {
         if (type in LayerClassMap) {
             const layer = new LayerClassMap[type](session.getPlatformFeatures());
             layer.loadState(l);
-            layer.stopEdit();
             session.addLayer(layer);
+            layer.saveState();
         }
     });
     session.virtualScreen.redraw();
@@ -236,15 +236,14 @@ export function loadLayers(layers: any[]) {
 
 export function saveLayers() {
     const session = useSession();
+    const packedSession = JSON.stringify(session.state.layers.map((l) => l.getState()));
     if (window.top !== window.self) {
-        postParentMessage('updateLayers', JSON.stringify(session.state.layers.map((l) => l.getState())));
+        postParentMessage('updateLayers', packedSession);
         postParentMessage('updateThumbnail', session.virtualScreen.canvas.toDataURL());
     } else {
-        localStorage.setItem(
-            `${session.state.platform}_lopaka_layers`,
-            JSON.stringify(session.state.layers.map((l) => l.getState()))
-        );
+        localStorage.setItem(`${session.state.platform}_lopaka_layers`, packedSession);
     }
+    console.log('Saved session size', packedSession.length, 'bytes');
 }
 // for testing
 window['saveLayers'] = saveLayers;

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -4,6 +4,7 @@ import {getFont, loadFont} from '../draw/fonts';
 import {VirtualScreen} from '../draw/virtual-screen';
 import {Editor} from '../editor/editor';
 import {AdafruitPlatform} from '../platforms/adafruit';
+import {AdafruitMonochromePlatform} from '../platforms/adafruit_mono';
 import {FlipperPlatform} from '../platforms/flipper';
 import {U8g2Platform} from '../platforms/u8g2';
 import {Uint32RawPlatform} from '../platforms/uint32-raw';
@@ -20,7 +21,6 @@ import {LineLayer} from './layers/line.layer';
 import {PaintLayer} from './layers/paint.layer';
 import {TextLayer} from './layers/text.layer';
 import {Point} from './point';
-import {AdafruitMonochromePlatform} from '../platforms/adafruit_mono';
 
 const sessions = new Map<string, UnwrapRef<Session>>();
 let currentSessionId = null;
@@ -38,7 +38,7 @@ export class Session {
     id: string = generateUID();
     platforms: {[key: string]: Platform} = {
         [U8g2Platform.id]: new U8g2Platform(),
-        // [AdafruitPlatform.id]: new AdafruitPlatform(),
+        [AdafruitPlatform.id]: new AdafruitPlatform(),
         [AdafruitMonochromePlatform.id]: new AdafruitMonochromePlatform(),
         [Uint32RawPlatform.id]: new Uint32RawPlatform(),
         [FlipperPlatform.id]: new FlipperPlatform(),
@@ -172,6 +172,7 @@ export class Session {
         this.state.platform = name;
         const fonts = this.platforms[name].getFonts();
         this.lock();
+        this.editor.clear();
         // preload default font
         return Promise.all(fonts.map((font) => loadFont(font))).then(() => {
             this.editor.font = getFont(fonts[0].name);

--- a/src/draw/draw-context.ts
+++ b/src/draw/draw-context.ts
@@ -15,8 +15,12 @@ export class DrawContext {
         return this;
     }
 
-    drawImage(image: OffscreenCanvas, position: Point) {
-        this.ctx.drawImage(image, position.x, position.y);
+    drawImage(image: OffscreenCanvas | ImageData, position: Point) {
+        if (image instanceof ImageData) {
+            this.ctx.putImageData(image, position.x, position.y);
+        } else {
+            this.ctx.drawImage(image, position.x, position.y);
+        }
     }
 
     line(from: Point, to: Point): DrawContext {

--- a/src/draw/plugins/draw.plugin.ts
+++ b/src/draw/plugins/draw.plugin.ts
@@ -7,5 +7,5 @@ export abstract class DrawPlugin {
     static offset: Point = new Point(30, 30);
     constructor(protected session: Session) {}
 
-    public abstract update(ctx: CanvasRenderingContext2D, point: Point): void;
+    public abstract update(ctx: CanvasRenderingContext2D, point: Point, event: MouseEvent): void;
 }

--- a/src/draw/plugins/paint-highlight.plugin.ts
+++ b/src/draw/plugins/paint-highlight.plugin.ts
@@ -2,6 +2,7 @@ import {PaintLayer} from '../../core/layers/paint.layer';
 import {Point} from '../../core/point';
 import {AbstractEditorPlugin} from '../../editor/plugins/abstract-editor.plugin';
 import {PaintPlugin} from '../../editor/plugins/paint.plugin';
+import {DrawContext} from '../draw-context';
 import {DrawPlugin} from './draw.plugin';
 
 export class PaintHighlightPlugin extends DrawPlugin {
@@ -13,7 +14,7 @@ export class PaintHighlightPlugin extends DrawPlugin {
                 (p: AbstractEditorPlugin) => p instanceof PaintPlugin
             ) as PaintPlugin;
         }
-        const {display, scale} = this.session.state;
+        const {scale} = this.session.state;
         if (point) {
             if (
                 event.shiftKey &&
@@ -21,14 +22,14 @@ export class PaintHighlightPlugin extends DrawPlugin {
                 this.session.editor.state.activeLayer instanceof PaintLayer &&
                 this.paintEditorPlugin.lastPoint
             ) {
-                console.log('paint highlight', point, this.paintEditorPlugin.lastPoint);
+                const lastPoint = this.paintEditorPlugin.lastPoint.clone().add(0.5).multiply(scale);
                 ctx.save();
                 ctx.beginPath();
                 ctx.moveTo(point.x, point.y);
-                ctx.lineTo(this.paintEditorPlugin.lastPoint.x * scale.x, this.paintEditorPlugin.lastPoint.y * scale.y);
-                ctx.strokeStyle = 'rgba(255, 255, 255, 0.5)';
-                ctx.setLineDash([5, 5]);
-                ctx.lineWidth = 2;
+                ctx.lineTo(lastPoint.x, lastPoint.y);
+                ctx.strokeStyle = 'rgba(200, 200, 200, 0.4)';
+                ctx.setLineDash([scale.x * 2, scale.x]);
+                ctx.lineWidth = scale.x;
                 ctx.stroke();
                 ctx.restore();
             }

--- a/src/draw/plugins/paint-highlight.plugin.ts
+++ b/src/draw/plugins/paint-highlight.plugin.ts
@@ -1,0 +1,37 @@
+import {PaintLayer} from '../../core/layers/paint.layer';
+import {Point} from '../../core/point';
+import {AbstractEditorPlugin} from '../../editor/plugins/abstract-editor.plugin';
+import {PaintPlugin} from '../../editor/plugins/paint.plugin';
+import {DrawPlugin} from './draw.plugin';
+
+export class PaintHighlightPlugin extends DrawPlugin {
+    paintEditorPlugin: PaintPlugin;
+
+    public update(ctx: CanvasRenderingContext2D, point: Point, event: MouseEvent): void {
+        if (!this.paintEditorPlugin) {
+            this.paintEditorPlugin = this.session.editor.plugins.find(
+                (p: AbstractEditorPlugin) => p instanceof PaintPlugin
+            ) as PaintPlugin;
+        }
+        const {display, scale} = this.session.state;
+        if (point) {
+            if (
+                event.shiftKey &&
+                this.session.editor.state.activeLayer &&
+                this.session.editor.state.activeLayer instanceof PaintLayer &&
+                this.paintEditorPlugin.lastPoint
+            ) {
+                console.log('paint highlight', point, this.paintEditorPlugin.lastPoint);
+                ctx.save();
+                ctx.beginPath();
+                ctx.moveTo(point.x, point.y);
+                ctx.lineTo(this.paintEditorPlugin.lastPoint.x * scale.x, this.paintEditorPlugin.lastPoint.y * scale.y);
+                ctx.strokeStyle = 'rgba(255, 255, 255, 0.5)';
+                ctx.setLineDash([5, 5]);
+                ctx.lineWidth = 2;
+                ctx.stroke();
+                ctx.restore();
+            }
+        }
+    }
+}

--- a/src/draw/virtual-screen.ts
+++ b/src/draw/virtual-screen.ts
@@ -8,6 +8,7 @@ import {HighlightPlugin} from './plugins/highlight.plugin';
 import {PointerPlugin} from './plugins/pointer.plugin';
 import {AbstractLayer} from '../core/layers/abstract.layer';
 import {ResizeIconsPlugin} from './plugins/resize-icons.plugin';
+import {PaintHighlightPlugin} from './plugins/paint-highlight.plugin';
 
 type VirtualScreenOptions = {
     ruler: boolean;
@@ -52,6 +53,7 @@ export class VirtualScreen {
             this.plugins.push(new PointerPlugin(session));
         }
         this.plugins.push(new ResizeIconsPlugin(session));
+        this.plugins.push(new PaintHighlightPlugin(session));
         this.scope = new EffectScope();
         this.scope.run(() => {
             this.state = reactive({
@@ -93,7 +95,7 @@ export class VirtualScreen {
         this.redraw();
     }
 
-    updateMousePosition(position: Point) {
+    updateMousePosition(position: Point, event: MouseEvent) {
         if (this.pluginLayer) {
             requestAnimationFrame(() => {
                 const ctx = this.pluginLayerContext;
@@ -102,7 +104,7 @@ export class VirtualScreen {
                     ctx.save();
                     ctx.scale(2, 2);
                     ctx.translate(DrawPlugin.offset.x, DrawPlugin.offset.y);
-                    plugin.update(ctx, position);
+                    plugin.update(ctx, position, event);
                     ctx.setTransform(1, 0, 0, 1, 0, 0);
                     ctx.restore();
                 });
@@ -181,7 +183,7 @@ export class VirtualScreen {
                     ctx.save();
                     ctx.scale(2, 2);
                     ctx.translate(DrawPlugin.offset.x, DrawPlugin.offset.y);
-                    plugin.update(ctx, null);
+                    plugin.update(ctx, null, null);
                     ctx.setTransform(1, 0, 0, 1, 0, 0);
                     ctx.restore();
                 });

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -89,6 +89,10 @@ export class Editor {
         );
     }
 
+    clear(): void {
+        this.plugins.forEach((p: AbstractEditorPlugin) => p.onClear());
+    }
+
     setTool(name: string) {
         if (this.state.activeTool) {
             this.state.activeTool.onDeactivate();

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -91,6 +91,7 @@ export class Editor {
 
     clear(): void {
         this.plugins.forEach((p: AbstractEditorPlugin) => p.onClear());
+        this.state.activeTool = null;
     }
 
     setTool(name: string) {

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -140,7 +140,7 @@ export class Editor {
                     this.onMouseDoubleClick(point, event);
                     break;
             }
-            virtualScreen.updateMousePosition(screenPoint);
+            virtualScreen.updateMousePosition(screenPoint, event);
         }
     };
 

--- a/src/editor/plugins/abstract-editor.plugin.ts
+++ b/src/editor/plugins/abstract-editor.plugin.ts
@@ -19,4 +19,5 @@ export abstract class AbstractEditorPlugin {
     onMouseDoubleClick(point: Point, event: MouseEvent): void {}
     onKeyDown(key: Keys, event: KeyboardEvent): void {}
     onDrop(point: Point, event: DragEvent): void {}
+    onClear(): void {}
 }

--- a/src/editor/plugins/copy.plugin.ts
+++ b/src/editor/plugins/copy.plugin.ts
@@ -43,4 +43,7 @@ export class CopyPlugin extends AbstractEditorPlugin {
             }
         }
     }
+    onClear(): void {
+        this.buffer.splice(0);
+    }
 }

--- a/src/editor/plugins/copy.plugin.ts
+++ b/src/editor/plugins/copy.plugin.ts
@@ -44,6 +44,6 @@ export class CopyPlugin extends AbstractEditorPlugin {
         }
     }
     onClear(): void {
-        this.buffer.splice(0);
+        this.buffer = null;
     }
 }

--- a/src/editor/plugins/image-drop.plugin.ts
+++ b/src/editor/plugins/image-drop.plugin.ts
@@ -32,9 +32,9 @@ export class ImageDropPlugin extends AbstractEditorPlugin {
         newLayer.size = size;
         newLayer.position = point.clone().subtract(size.clone().divide(2));
         newLayer.selected = true;
+        newLayer.modifiers.icon.setValue(icon);
         newLayer.stopEdit();
         this.session.addLayer(newLayer);
-        newLayer.modifiers.icon.setValue(icon);
         virtualScreen.redraw();
     }
 }

--- a/src/editor/plugins/paint.plugin.ts
+++ b/src/editor/plugins/paint.plugin.ts
@@ -19,6 +19,7 @@ export class PaintPlugin extends AbstractEditorPlugin {
                     const layer = (this.session.editor.state.activeLayer = activeTool.createLayer());
                     layer.selected = true;
                     this.session.addLayer(layer);
+                    this.session.editor.state.activeLayer = layer;
                 }
             }
             this.session.editor.state.activeLayer.startEdit(EditMode.CREATING, point);

--- a/src/editor/plugins/paint.plugin.ts
+++ b/src/editor/plugins/paint.plugin.ts
@@ -24,8 +24,16 @@ export class PaintPlugin extends AbstractEditorPlugin {
             }
             const layer = this.session.editor.state.activeLayer;
             layer.startEdit(EditMode.CREATING, point);
-            layer.edit(point.clone(), event);
+            if (event.shiftKey) {
+                if (this.firstPoint) {
+                    layer.edit(this.firstPoint, event);
+                    layer.edit(point, event);
+                }
+            } else {
+                layer.edit(point.clone(), event);
+            }
         }
+        this.firstPoint = point;
         this.session.virtualScreen.redraw();
     }
 
@@ -34,6 +42,7 @@ export class PaintPlugin extends AbstractEditorPlugin {
         if (this.captured) {
             activeLayer.edit(point.clone(), event);
             this.session.virtualScreen.redraw();
+            this.firstPoint = point;
         }
     }
 

--- a/src/editor/plugins/paint.plugin.ts
+++ b/src/editor/plugins/paint.plugin.ts
@@ -54,4 +54,8 @@ export class PaintPlugin extends AbstractEditorPlugin {
             this.session.virtualScreen.redraw();
         }
     }
+
+    onClear(): void {
+        this.firstPoint = null;
+    }
 }

--- a/src/editor/plugins/paint.plugin.ts
+++ b/src/editor/plugins/paint.plugin.ts
@@ -22,7 +22,9 @@ export class PaintPlugin extends AbstractEditorPlugin {
                     this.session.editor.state.activeLayer = layer;
                 }
             }
-            this.session.editor.state.activeLayer.startEdit(EditMode.CREATING, point);
+            const layer = this.session.editor.state.activeLayer;
+            layer.startEdit(EditMode.CREATING, point);
+            layer.edit(point.clone(), event);
         }
         this.session.virtualScreen.redraw();
     }

--- a/src/editor/plugins/paint.plugin.ts
+++ b/src/editor/plugins/paint.plugin.ts
@@ -33,7 +33,7 @@ export class PaintPlugin extends AbstractEditorPlugin {
                 layer.edit(point.clone(), event);
             }
         }
-        this.lastPoint = point;
+        this.lastPoint = point.clone().floor();
         this.session.virtualScreen.redraw();
     }
 

--- a/src/editor/plugins/paint.plugin.ts
+++ b/src/editor/plugins/paint.plugin.ts
@@ -4,7 +4,7 @@ import {Point} from '../../core/point';
 import {AbstractEditorPlugin} from './abstract-editor.plugin';
 
 export class PaintPlugin extends AbstractEditorPlugin {
-    firstPoint: Point;
+    lastPoint: Point;
     captured: boolean = false;
 
     onMouseDown(point: Point, event: MouseEvent): void {
@@ -25,15 +25,15 @@ export class PaintPlugin extends AbstractEditorPlugin {
             const layer = this.session.editor.state.activeLayer;
             layer.startEdit(EditMode.CREATING, point);
             if (event.shiftKey) {
-                if (this.firstPoint) {
-                    layer.edit(this.firstPoint, event);
+                if (this.lastPoint) {
+                    layer.edit(this.lastPoint, event);
                     layer.edit(point, event);
                 }
             } else {
                 layer.edit(point.clone(), event);
             }
         }
-        this.firstPoint = point;
+        this.lastPoint = point;
         this.session.virtualScreen.redraw();
     }
 
@@ -42,7 +42,7 @@ export class PaintPlugin extends AbstractEditorPlugin {
         if (this.captured) {
             activeLayer.edit(point.clone(), event);
             this.session.virtualScreen.redraw();
-            this.firstPoint = point;
+            this.lastPoint = point;
         }
     }
 
@@ -56,6 +56,6 @@ export class PaintPlugin extends AbstractEditorPlugin {
     }
 
     onClear(): void {
-        this.firstPoint = null;
+        this.lastPoint = null;
     }
 }

--- a/src/editor/tools/abstract.tool.ts
+++ b/src/editor/tools/abstract.tool.ts
@@ -18,9 +18,7 @@ export abstract class AbstractTool {
         return true;
     }
 
-    onActivate(): void {
-        // do nothing
-    }
+    onActivate(): void {}
 
     onDeactivate(): void {
         // do nothing

--- a/src/editor/tools/paint.tool.ts
+++ b/src/editor/tools/paint.tool.ts
@@ -1,8 +1,7 @@
 import {AbstractImageLayer} from '../../core/layers/abstract-image.layer';
-import {AbstractLayer, EditMode} from '../../core/layers/abstract.layer';
+import {AbstractLayer} from '../../core/layers/abstract.layer';
 import {PaintLayer} from '../../core/layers/paint.layer';
 import {Point} from '../../core/point';
-import {DrawPlugin} from '../../draw/plugins/draw.plugin';
 import {FlipperPlatform} from '../../platforms/flipper';
 import {AbstractEditorPlugin} from '../plugins/abstract-editor.plugin';
 import {PaintPlugin} from '../plugins/paint.plugin';

--- a/src/editor/tools/paint.tool.ts
+++ b/src/editor/tools/paint.tool.ts
@@ -49,8 +49,8 @@ export class PaintTool extends AbstractTool {
                 }
             } else {
                 this.editor.state.activeLayer.stopEdit();
-                this.editor.state.activeLayer = null;
             }
+            this.editor.state.activeLayer = null;
         }
     }
 }

--- a/src/editor/tools/paint.tool.ts
+++ b/src/editor/tools/paint.tool.ts
@@ -2,7 +2,10 @@ import {AbstractImageLayer} from '../../core/layers/abstract-image.layer';
 import {AbstractLayer, EditMode} from '../../core/layers/abstract.layer';
 import {PaintLayer} from '../../core/layers/paint.layer';
 import {Point} from '../../core/point';
+import {DrawPlugin} from '../../draw/plugins/draw.plugin';
 import {FlipperPlatform} from '../../platforms/flipper';
+import {AbstractEditorPlugin} from '../plugins/abstract-editor.plugin';
+import {PaintPlugin} from '../plugins/paint.plugin';
 import {AbstractTool} from './abstract.tool';
 
 export class PaintTool extends AbstractTool {
@@ -31,6 +34,10 @@ export class PaintTool extends AbstractTool {
             this.editor.session.addLayer(layer);
             layer.selected = true;
             this.editor.state.activeLayer = layer;
+        }
+        const paintPlugin = this.editor.plugins.find((p: AbstractEditorPlugin) => p instanceof PaintPlugin);
+        if (paintPlugin) {
+            paintPlugin.onClear();
         }
     }
 

--- a/src/editor/tools/paint.tool.ts
+++ b/src/editor/tools/paint.tool.ts
@@ -25,6 +25,7 @@ export class PaintTool extends AbstractTool {
         if (selectedPaints.length) {
             const layer = selectedPaints[0];
             layer.selected = true;
+            this.editor.state.activeLayer = layer;
         } else {
             const layer = this.createLayer();
             this.editor.session.addLayer(layer);

--- a/src/editor/tools/paint.tool.ts
+++ b/src/editor/tools/paint.tool.ts
@@ -1,3 +1,4 @@
+import {AbstractImageLayer} from '../../core/layers/abstract-image.layer';
 import {AbstractLayer, EditMode} from '../../core/layers/abstract.layer';
 import {PaintLayer} from '../../core/layers/paint.layer';
 import {Point} from '../../core/point';
@@ -24,13 +25,25 @@ export class PaintTool extends AbstractTool {
         if (selectedPaints.length) {
             const layer = selectedPaints[0];
             layer.selected = true;
+        } else {
+            const layer = this.createLayer();
+            this.editor.session.addLayer(layer);
+            layer.selected = true;
+            this.editor.state.activeLayer = layer;
         }
     }
 
     onDeactivate(): void {
         if (this.editor.state.activeLayer) {
-            this.editor.state.activeLayer.stopEdit();
-            this.editor.state.activeLayer = null;
+            if (this.editor.state.activeLayer instanceof AbstractImageLayer) {
+                const layer: AbstractImageLayer = this.editor.state.activeLayer;
+                if (!layer.data) {
+                    this.editor.session.removeLayer(layer);
+                }
+            } else {
+                this.editor.state.activeLayer.stopEdit();
+                this.editor.state.activeLayer = null;
+            }
         }
     }
 }

--- a/src/platforms/__snapshots__/adafruit.test.ts.snap
+++ b/src/platforms/__snapshots__/adafruit.test.ts.snap
@@ -17,5 +17,5 @@ display.drawPixel(72, 12,  0x0);
 display.drawCircle(20, 41, 12,  0x1F);
 display.fillCircle(17, 43, 3, 0xF800);
 display.drawRect(44, 29, 44, 28, 0x7E0);
-display.drawBitmap(0, 0, image_draw_rrsjcz4oz2ln6jx4y4_bits, 128, 64, 0xF800);"
+display.drawBitmap(0, 0, image_draw_rrsjcz4oz2ln6jx4y4_bits, 128, 64, 0x0);"
 `;

--- a/src/platforms/__snapshots__/flipper.test.ts.snap
+++ b/src/platforms/__snapshots__/flipper.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Flipper zero platform > generating source code 1`] = `
-"
+"// PAINT tool is not yet supported for Flipper Zero, sorry. It is being ignored from code output
 canvas_draw_box(canvas, 107, 46, 18, 15);
 canvas_draw_box(canvas, 97, 2, 27, 11);
 canvas_draw_box(canvas, 106, 19, 19, 18);

--- a/src/platforms/adafruit.ts
+++ b/src/platforms/adafruit.ts
@@ -1,3 +1,4 @@
+import {AbstractImageLayer} from '../core/layers/abstract-image.layer';
 import {AbstractLayer} from '../core/layers/abstract.layer';
 import {BoxLayer} from '../core/layers/box.layer';
 import {CircleLayer} from '../core/layers/circle.layer';
@@ -77,15 +78,9 @@ display.print("${layer.text}");`);
 
     addImage(layer: IconLayer | PaintLayer, source: TSourceCode): void {
         let image;
-        if (layer instanceof IconLayer) {
-            if (!layer.image) return;
-            image = layer.image;
-        } else if (layer instanceof PaintLayer) {
-            if (!layer.position || !layer.size.x || !layer.size.y) return;
-            image = layer
-                .getBuffer()
-                .getContext('2d')
-                .getImageData(layer.position.x, layer.position.y, layer.size.x, layer.size.y);
+        if (layer instanceof AbstractImageLayer) {
+            if (!layer.data) return;
+            image = layer.data;
         }
         const XBMP = imgDataToXBMP(image, 0, 0, layer.size.x, layer.size.y, true);
         const varName = `image_${toCppVariableName(layer.name)}_bits`;

--- a/src/platforms/flipper.ts
+++ b/src/platforms/flipper.ts
@@ -13,11 +13,11 @@ import { PaintLayer } from "../core/layers/paint.layer";
 import { AbstractLayer } from "../core/layers/abstract.layer";
 
 const flipperFontMap = {
-    'helvB08_tr': "FontPrimary",
-    'haxrcorp4089_tr': "FontSecondary",
-    'profont11_mr': "FontKeyboard",
-    'profont22_tr': "FontBigNumbers",
-}
+    helvB08_tr: 'FontPrimary',
+    haxrcorp4089_tr: 'FontSecondary',
+    profont11_mr: 'FontKeyboard',
+    profont22_tr: 'FontBigNumbers'
+};
 
 export class FlipperPlatform extends Platform {
     public static id = 'flipper';
@@ -26,7 +26,7 @@ export class FlipperPlatform extends Platform {
     protected fonts: TPlatformFont[] = [
         fontTypes['haxrcorp4089_tr'],
         fontTypes['helvB08_tr'],
-        fontTypes['profont22_tr'],
+        fontTypes['profont22_tr']
     ];
 
     public generateSourceCode(layers: AbstractLayer[], ctx?: OffscreenCanvasRenderingContext2D): TSourceCode {

--- a/src/platforms/layers.mock.ts
+++ b/src/platforms/layers.mock.ts
@@ -112,14 +112,15 @@ export const layersMock: AbstractLayer[] = [
         p: [0, 0],
         u: 'rrsjcz4oz2ln6jx4y4',
         s: [128, 64],
-        d: []
+        d: 'eNpjYECA/1gAAxZ5dDFcctjMZcADCMkPZTUAc/dPsQ=='
     }
 ].map((l) => {
     const type: ELayerType = l.t as any;
     const layer = new LayerClassMap[type]({
         hasCustomFontSize: false,
         hasInvertedColors: false,
-        hasRGBSupport: false
+        hasRGBSupport: false,
+        defaultColor: '#000000'
     });
     layer.loadState(l);
     return layer;

--- a/src/platforms/u8g2.ts
+++ b/src/platforms/u8g2.ts
@@ -1,20 +1,21 @@
-import {imgDataToXBMP, toCppVariableName} from '../utils';
-import {Platform} from './platform';
+import {AbstractImageLayer} from '../core/layers/abstract-image.layer';
 import {AbstractLayer} from '../core/layers/abstract.layer';
-import {DotLayer} from '../core/layers/dot.layer';
-import {LineLayer} from '../core/layers/line.layer';
-import {TextLayer} from '../core/layers/text.layer';
 import {BoxLayer} from '../core/layers/box.layer';
-import {FrameLayer} from '../core/layers/frame.layer';
 import {CircleLayer} from '../core/layers/circle.layer';
 import {DiscLayer} from '../core/layers/disc.layer';
+import {DotLayer} from '../core/layers/dot.layer';
+import {FrameLayer} from '../core/layers/frame.layer';
 import {IconLayer} from '../core/layers/icon.layer';
+import {LineLayer} from '../core/layers/line.layer';
 import {PaintLayer} from '../core/layers/paint.layer';
+import {TextLayer} from '../core/layers/text.layer';
 import {fontTypes} from '../draw/fonts/fontTypes';
+import {imgDataToXBMP, toCppVariableName} from '../utils';
+import {Platform} from './platform';
 
 const u8g2FontMap = {
-    'f4x6_tr': "4x6_tr",
-}
+    f4x6_tr: '4x6_tr'
+};
 
 export class U8g2Platform extends Platform {
     public static id = 'u8g2';
@@ -72,15 +73,9 @@ u8g2.drawStr(${layer.position.x}, ${layer.position.y}, "${layer.text}");`);
     }
     addImage(layer: IconLayer | PaintLayer, source: TSourceCode): void {
         let image;
-        if (layer instanceof IconLayer) {
-            if (!layer.image) return;
-            image = layer.image;
-        } else if (layer instanceof PaintLayer) {
-            if (!layer.position || !layer.size.x || !layer.size.y) return;
-            image = layer
-                .getBuffer()
-                .getContext('2d')
-                .getImageData(layer.position.x, layer.position.y, layer.size.x, layer.size.y);
+        if (layer instanceof AbstractImageLayer) {
+            if (!layer.data) return;
+            image = layer.data;
         }
         const XBMP = imgDataToXBMP(image, 0, 0, layer.size.x, layer.size.y);
         const varName = `image_${toCppVariableName(layer.name)}_bits`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
 import {decode, encode} from 'base64-arraybuffer';
 import pako from 'pako';
-
 function bitswap(b) {
     b = ((b & 0xf0) >> 4) | ((b & 0x0f) << 4);
     b = ((b & 0xcc) >> 2) | ((b & 0x33) << 2);
@@ -28,6 +27,16 @@ export async function loadImageAsync(src): Promise<HTMLImageElement> {
         img.onerror = reject;
         img.onload = () => resolve(img);
     });
+}
+
+export async function loadImageDataAsync(src): Promise<ImageData> {
+    const img = await loadImageAsync(src);
+    const canvas = document.createElement('canvas');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(img, 0, 0);
+    return ctx.getImageData(0, 0, img.width, img.height);
 }
 
 export function hexToRgb(hexColor: string) {
@@ -181,7 +190,7 @@ export function toCppVariableName(str) {
 }
 
 export function generateUID() {
-    return Math.random().toString(36).substring(2) + Date.now().toString(36);
+    return Date.now().toString(32);
 }
 
 export function postParentMessage(type, data) {


### PR DESCRIPTION
The paint layer stores data in packed imageData instead of points array.
The paint layer and icon layer share a common abstract class containing saveState, loadState, and draw methods.
A layer modifier can only have getValue method and will be read-only in the inspector view.
Reduced layer uid size