### PR TITLE
fix: update Dockerfile and add Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,60 @@
+name: 'Publish Docker Image'
+
+on:
+  pull_request:
+    types:
+      - closed
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: woomoo/lopaka
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true && 
+      github.event.pull_request.base.ref == 'main' && 
+      contains(github.event.pull_request.labels.*.name, 'docker')
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get version from package.json
+        id: version
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=,suffix=,format=short
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM node:22.3.0-alpine AS build-stage
 
 WORKDIR /app
 
-RUN corepack enable \
-    && corepack prepare pnpm@8.15.9 --activate
+RUN npm install -g pnpm@10.30.3
 
 COPY package.json pnpm-lock.yaml ./
 
@@ -13,9 +12,6 @@ RUN pnpm install --frozen-lockfile
 COPY . .
 
 RUN NODE_OPTIONS="--max-old-space-size=16384" pnpm build
-
-# Remove dev dependencies after build
-RUN pnpm prune --prod
 
 
 FROM nginx:alpine-slim


### PR DESCRIPTION
- Fix pnpm installation in Dockerfile (use npm instead of corepack)
- Remove broken pnpm prune step
- Add GitHub Actions workflow to publish Docker image on PR merge

Fixes #234