### PR TITLE
create text layers at visible viewport center, clamp to canvas

### DIFF
--- a/src/core/layers/text.layer.ts
+++ b/src/core/layers/text.layer.ts
@@ -58,7 +58,7 @@ export class TextLayer extends AbstractLayer {
         x: {
             getValue: () => this.position.x,
             setValue: (v: number) => {
-                this.position.x = v;
+                this.position.x = Math.max(0, Math.min(this.buffer.width - this.bounds.w, v));
                 this.updateBounds();
                 this.draw();
             },
@@ -71,7 +71,7 @@ export class TextLayer extends AbstractLayer {
         y: {
             getValue: () => this.position.y,
             setValue: (v: number) => {
-                this.position.y = v;
+                this.position.y = Math.max(this.bounds.h, Math.min(this.buffer.height, v));
                 this.updateBounds();
                 this.draw();
             },
@@ -309,9 +309,13 @@ export class TextLayer extends AbstractLayer {
         }
         const {position, text, firstPoint, editPoint} = this.editState;
         switch (this.mode) {
-            case EditMode.MOVING:
-                this.position = position.clone().add(point.clone().subtract(firstPoint)).round();
+            case EditMode.MOVING: {
+                const pos = position.clone().add(point.clone().subtract(firstPoint)).round();
+                pos.x = Math.max(0, Math.min(this.buffer.width - this.bounds.w, pos.x));
+                pos.y = Math.max(this.bounds.h, Math.min(this.buffer.height, pos.y));
+                this.position = pos;
                 break;
+            }
             case EditMode.RESIZING:
                 editPoint.move(firstPoint.clone().subtract(point), originalEvent);
                 break;

--- a/src/editor/editor.test.ts
+++ b/src/editor/editor.test.ts
@@ -1,0 +1,68 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {Point} from '../core/point';
+import {Editor} from './editor';
+
+describe('Editor.getViewportCenterInCanvas', () => {
+    beforeEach(() => {
+        vi.stubGlobal('DOMMatrix', function (this: any, transform?: string) {
+            this.m41 = 0;
+            this.m42 = 0;
+            this.scale = vi.fn(() => this);
+            this.translate = vi.fn(() => this);
+            if (transform) {
+                const m = /translate\(([^,]+),\s*([^)]+)\)/.exec(transform);
+                if (m) {
+                    this.m41 = parseFloat(m[1].replace('px', ''));
+                    this.m42 = parseFloat(m[2].replace('px', ''));
+                }
+            }
+        } as any);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('returns display center when scrollContainer is null', () => {
+        const session = {
+            state: {
+                display: new Point(128, 64),
+                scale: new Point(1, 1),
+            },
+        };
+        const editor = new Editor(session as any);
+
+        const result = editor.getViewportCenterInCanvas();
+
+        expect(result.equals(new Point(64, 32).round())).toBe(true);
+    });
+
+    it('computes canvas-space center from DOM metrics', () => {
+        const session = {
+            state: {
+                display: new Point(128, 64),
+                scale: new Point(1, 1),
+            },
+        };
+        const editor = new Editor(session as any);
+
+        editor.scrollContainer = {
+            clientWidth: 200,
+            clientHeight: 100,
+        } as HTMLElement;
+
+        const wrapper = {
+            closest: vi.fn((_: string) => wrapper),
+        } as unknown as HTMLElement;
+        editor.container = wrapper;
+
+        vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+            transform: 'translate(100px, 50px)',
+        } as CSSStyleDeclaration);
+
+        const result = editor.getViewportCenterInCanvas();
+
+        // cx = (200/2 - 100) / 1 = 0, cy = (100/2 - 50) / 1 = 0
+        expect(result.equals(new Point(0, 0))).toBe(true);
+    });
+});

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -125,6 +125,24 @@ export class Editor {
         this.state.textEditMode++;
     }
 
+    getViewportCenterInCanvas(): Point {
+        const {state} = this.session;
+        const sc = this.scrollContainer;
+        const canvasWrapper = this.container?.closest('.canvas-wrapper') as HTMLElement;
+
+        if (sc && canvasWrapper) {
+            const matrix = new DOMMatrix(getComputedStyle(canvasWrapper).transform);
+            const cx = (sc.clientWidth  / 2 - matrix.m41) / state.scale.x;
+            const cy = (sc.clientHeight / 2 - matrix.m42) / state.scale.y;
+            return new Point(
+                Math.max(0, Math.min(state.display.x - 1, cx)),
+                Math.max(0, Math.min(state.display.y - 1, cy))
+            ).round();
+        }
+
+        return new Point(state.display.x / 2, state.display.y / 2).round();
+    }
+
     clear(): void {
         this.plugins.forEach((p: AbstractEditorPlugin) => p.onClear());
         this.state.activeTool = null;

--- a/src/editor/tools/text-area.tool.test.ts
+++ b/src/editor/tools/text-area.tool.test.ts
@@ -122,6 +122,10 @@ const createTestContext = (): TestContext => {
         setTool: vi.fn((name: string | null) => {
             editorState.activeTool = name ? {} : null;
         }),
+        getViewportCenterInCanvas: () => {
+            const d = session.state.display;
+            return new Point(d.x / 2, d.y / 2).round();
+        },
     } as TestContext['editor'];
     // Wire the editor back onto the session for tool access.
     session.editor = editor;

--- a/src/editor/tools/text-area.tool.ts
+++ b/src/editor/tools/text-area.tool.ts
@@ -25,7 +25,11 @@ export class TextAreaTool extends AbstractTool {
         const {layersManager, state} = this.editor.session;
         // Create the text area layer and compute its centered position.
         const layer = this.createLayer() as TextAreaLayer;
-        const position = new Point((state.display.x - layer.size.x) / 2, (state.display.y - layer.size.y) / 2).round();
+        const center = this.editor.getViewportCenterInCanvas();
+        const position = new Point(
+            Math.max(0, Math.min(state.display.x - layer.size.x, center.x - layer.size.x / 2)),
+            Math.max(0, Math.min(state.display.y - layer.size.y, center.y - layer.size.y / 2))
+        ).round();
         // Clear selection before adding the text area layer.
         layersManager.clearSelection();
         this.editor.state.activeLayer = layer;

--- a/src/editor/tools/text.tool.test.ts
+++ b/src/editor/tools/text.tool.test.ts
@@ -1,0 +1,154 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {Point} from '../../core/point';
+import {TextLayer} from '../../core/layers/text.layer';
+import {TextTool} from './text.tool';
+import {PixelatedDrawingRenderer} from '../../draw/renderers';
+import {FontFormat} from '../../draw/fonts/font';
+import type {AbstractLayer} from '../../core/layers/abstract.layer';
+import type {TPlatformFeatures} from '../../platforms/platform';
+import * as fonts from '/src/draw/fonts';
+
+const PLATFORM_ID = 'lvgl';
+
+const FEATURES: TPlatformFeatures = {
+    hasCustomFontSize: true,
+    hasInvertedColors: false,
+    hasRGBSupport: true,
+    hasIndexedColors: false,
+    hasRoundCorners: true,
+    defaultColor: '#ffffff',
+    interfaceColors: {
+        selectColor: '#fff',
+        resizeIconColor: '#fff',
+        hoverColor: '#fff',
+        rulerColor: '#fff',
+        rulerLineColor: '#fff',
+        selectionStrokeColor: '#fff',
+    },
+};
+
+const FAKE_FONT = {
+    name: 'FakeFont',
+    format: FontFormat.FORMAT_TTF,
+    getSize: (_: unknown, text: string) => new Point(text.length * 6, 10),
+    drawText: () => undefined,
+};
+
+const PLATFORM_FONTS: TPlatformFont[] = [
+    {
+        name: 'FakeFont',
+        title: 'Fake Font',
+        file: 'fake.ttf',
+        format: FontFormat.FORMAT_TTF,
+    },
+];
+
+type TestContext = {
+    editor: {
+        session: any;
+        font: unknown;
+        lastFontName: string | null;
+        state: {
+            activeLayer: AbstractLayer | null;
+            activeTool: unknown;
+        };
+        setTool: (name: string | null) => void;
+    };
+    session: {
+        state: {
+            display: Point;
+            platform: string;
+            customFonts: TPlatformFont[];
+            scale: Point;
+        };
+        platforms: Record<string, {getFonts: () => TPlatformFont[]}>;
+        getPlatformFeatures: () => TPlatformFeatures;
+        createRenderer: () => PixelatedDrawingRenderer;
+        addLayer: (layer: AbstractLayer) => void;
+        virtualScreen: {redraw: ReturnType<typeof vi.fn>};
+        layersManager: {
+            clearSelection: ReturnType<typeof vi.fn>;
+            selectLayer: ReturnType<typeof vi.fn>;
+        };
+        editor: unknown;
+    };
+    layers: AbstractLayer[];
+};
+
+const createTestContext = (): TestContext => {
+    const state = {
+        display: new Point(128, 64),
+        platform: PLATFORM_ID,
+        customFonts: [] as TPlatformFont[],
+        scale: new Point(1, 1),
+    };
+    const layers: AbstractLayer[] = [];
+    const session = {
+        state,
+        platforms: {
+            [PLATFORM_ID]: {
+                getFonts: () => PLATFORM_FONTS,
+            },
+        },
+        getPlatformFeatures: () => FEATURES,
+        createRenderer: () => new PixelatedDrawingRenderer(),
+        addLayer: (layer: AbstractLayer) => {
+            layer.resize(state.display, state.scale);
+            layer.draw();
+            layers.push(layer);
+        },
+        virtualScreen: {
+            redraw: vi.fn(),
+        },
+        layersManager: {
+            clearSelection: vi.fn(),
+            selectLayer: vi.fn(),
+        },
+        editor: null,
+    } as TestContext['session'];
+    const editorState = {
+        activeLayer: null as AbstractLayer | null,
+        activeTool: null as unknown,
+    };
+    const editor = {
+        session,
+        font: null,
+        lastFontName: null,
+        state: editorState,
+        setTool: vi.fn((name: string | null) => {
+            editorState.activeTool = name ? {} : null;
+        }),
+        getViewportCenterInCanvas: () => {
+            const d = session.state.display;
+            return new Point(d.x / 2, d.y / 2).round();
+        },
+    } as TestContext['editor'];
+    session.editor = editor;
+    return {editor, session, layers};
+};
+
+describe('TextTool', () => {
+    beforeEach(() => {
+        vi.spyOn(fonts, 'getFont').mockReturnValue(FAKE_FONT as any);
+    });
+
+    it('centers the text layer and exits the tool on activation', () => {
+        const {editor, layers} = createTestContext();
+        const tool = new TextTool(editor as any);
+
+        tool.onActivate();
+
+        expect(layers).toHaveLength(1);
+        const layer = layers[0] as TextLayer;
+        expect(layer).toBeInstanceOf(TextLayer);
+
+        // Expected centered position derived from display center (64, 32)
+        // and layer bounds (w=24, h=10):
+        // x = max(0, min(128-24, 64-12)) = 52
+        // y = max(0, min(64-10, 32-5))  = 27
+        const expectedPosition = new Point(52, 27);
+        expect(layer.position.equals(expectedPosition)).toBe(true);
+
+        expect(editor.setTool).toHaveBeenCalledWith(null);
+    });
+});

--- a/src/editor/tools/text.tool.ts
+++ b/src/editor/tools/text.tool.ts
@@ -32,7 +32,11 @@ export class TextTool extends AbstractTool {
         layer.updateBounds();
         const bounds = layer.bounds;
         // Center the text bounds on the display.
-        const position = new Point((state.display.x - bounds.w) / 2, (state.display.y + bounds.h) / 2).round();
+        const center = this.editor.getViewportCenterInCanvas();
+        const position = new Point(
+            Math.max(0, Math.min(state.display.x - bounds.w, center.x - bounds.w / 2)),
+            Math.max(0, Math.min(state.display.y - bounds.h, center.y - bounds.h / 2))
+        ).round();
         
         this.editor.state.activeLayer.startEdit(EditMode.CREATING, position);
         this.editor.state.activeLayer.stopEdit();


### PR DESCRIPTION
src/editor/editor.ts - новый getViewportCenterInCanvas()
src/editor/tools/text.tool.ts - создание текста по центру вьюпорта
src/editor/tools/text-area.tool.ts - то же для textarea
src/editor/tools/text-area.tool.test.ts - мок для метода
src/core/layers/text.layer.ts - clamping при движении: перетаскивание и стрелки не дают тексту уйти за границы канваса